### PR TITLE
Add reward store with backend redemption

### DIFF
--- a/backend/models/rewardItem.js
+++ b/backend/models/rewardItem.js
@@ -1,0 +1,7 @@
+const rewardItems = [
+  { id: 'coffee', name: 'Free Coffee', cost: 50 },
+  { id: 'parking', name: 'Parking Voucher', cost: 100 },
+  { id: 'lunch', name: 'Lunch Coupon', cost: 200 }
+];
+
+module.exports = { rewardItems };

--- a/backend/models/rewardRedemption.js
+++ b/backend/models/rewardRedemption.js
@@ -1,0 +1,3 @@
+const rewardRedemptions = [];
+
+module.exports = { rewardRedemptions };

--- a/backend/routes/rewards.js
+++ b/backend/routes/rewards.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { authMiddleware, users } = require('../middleware/auth');
+const { rewardItems } = require('../models/rewardItem');
+const { rewardRedemptions } = require('../models/rewardRedemption');
+
+const router = express.Router();
+
+// List available rewards and current user points
+router.get('/', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.user.userId);
+  res.json({ rewards: rewardItems, points: user?.points || 0 });
+});
+
+// Redeem a reward using points
+router.post('/redeem', authMiddleware, (req, res) => {
+  const { rewardId } = req.body;
+  const reward = rewardItems.find(r => r.id === rewardId);
+  if (!reward) {
+    return res.status(404).json({ error: 'Reward not found' });
+  }
+
+  const user = users.find(u => u.id === req.user.userId);
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  user.points = user.points || 0;
+  if (user.points < reward.cost) {
+    return res.status(400).json({ error: 'Not enough points' });
+  }
+
+  user.points -= reward.cost;
+  rewardRedemptions.push({
+    userId: user.id,
+    rewardId: reward.id,
+    timestamp: new Date().toISOString()
+  });
+
+  res.json({ message: 'Reward redeemed', points: user.points });
+});
+
+module.exports = router;

--- a/src/components/RewardStore.tsx
+++ b/src/components/RewardStore.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface RewardItem {
+  id: string;
+  name: string;
+  cost: number;
+}
+
+export function RewardStore() {
+  const { user } = useAuth();
+  const [rewards, setRewards] = useState<RewardItem[]>([]);
+  const [points, setPoints] = useState(0);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    fetch('/api/rewards', {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('hypercourt_token')}`
+      }
+    })
+      .then(res => res.json())
+      .then(data => {
+        setRewards(data.rewards);
+        setPoints(data.points);
+      })
+      .catch(err => console.error('Failed to load rewards', err));
+  }, [user]);
+
+  const handleRedeem = async (rewardId: string) => {
+    try {
+      const res = await fetch('/api/rewards/redeem', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('hypercourt_token')}`
+        },
+        body: JSON.stringify({ rewardId })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Redemption failed');
+      }
+      setPoints(data.points);
+      setMessage('Reward redeemed');
+    } catch (err: any) {
+      setMessage(err.message);
+    }
+  };
+
+  if (!user) {
+    return <p className="text-center">Please log in to view rewards.</p>;
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Reward Store</h2>
+      <p className="mb-4">Points: {points}</p>
+      {message && <p className="mb-4 text-sm text-red-500">{message}</p>}
+      <ul className="space-y-2">
+        {rewards.map(reward => (
+          <li key={reward.id} className="flex justify-between items-center border p-2 rounded">
+            <span>{reward.name}</span>
+            <button
+              className="px-2 py-1 bg-blue-500 text-white rounded disabled:opacity-50"
+              disabled={points < reward.cost}
+              onClick={() => handleRedeem(reward.id)}
+            >
+              Redeem ({reward.cost})
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -31,3 +31,14 @@ export interface AIHistoryEntry {
   prompt: string;
   response: AIResponse;
 }
+export interface RewardItem {
+  id: string;
+  name: string;
+  cost: number;
+}
+
+export interface RewardRedemption {
+  userId: string;
+  rewardId: string;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- add in-memory RewardItem list and redemption log
- introduce rewards API with point deductions
- create RewardStore component for redeeming rewards

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689611b0bc308323a811ccd680b8e30a