### PR TITLE
Add localization support with language settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,16 @@ import AuthContainer from './components/AuthContainer';
 import MainApp from './components/MainApp';
 import ErrorBoundary from './components/ErrorBoundary';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
 
 function AppContent() {
   const { user, isLoading } = useAuth();
+  const { t } = useLanguage();
 
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-        <div className="text-xl">טוען...</div>
+        <div className="text-xl">{t('app.loading')}</div>
       </div>
     );
   }
@@ -21,9 +23,11 @@ function AppContent() {
 function App() {
   return (
     <ErrorBoundary>
-      <AuthProvider>
-        <AppContent />
-      </AuthProvider>
+      <LanguageProvider>
+        <AuthProvider>
+          <AppContent />
+        </AuthProvider>
+      </LanguageProvider>
     </ErrorBoundary>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,28 +1,30 @@
 import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { LogOut } from 'lucide-react';
+import { useLanguage } from '../contexts/LanguageContext';
 
 export default function Header() {
   const { user, logout } = useAuth();
+  const { t } = useLanguage();
 
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-blue-800">HyperCourt</h1>
-          <p className="text-sm text-gray-600">מערכת משפטית חכמה</p>
+          <h1 className="text-2xl font-bold text-blue-800">{t('header.title')}</h1>
+          <p className="text-sm text-gray-600">{t('header.subtitle')}</p>
         </div>
         
         <div className="flex items-center gap-4">
           <div className="text-right">
             <p className="text-sm font-medium text-gray-900">
-              ברוך הבא, {user?.email}
+              {t('header.welcome', { email: user?.email || '' })}
             </p>
             <p className="text-xs text-gray-500">
-              {user?.role === 'admin' ? 'מנהל מערכת' : 
-               user?.role === 'lawyer' ? 'עורך/ת דין' :
-               user?.role === 'judge' ? 'שופט/ת' :
-               user?.role === 'plaintiff' ? 'תובע/ת' : user?.role}
+              {user?.role === 'admin' ? t('header.roles.admin') :
+               user?.role === 'lawyer' ? t('header.roles.lawyer') :
+               user?.role === 'judge' ? t('header.roles.judge') :
+               user?.role === 'plaintiff' ? t('header.roles.plaintiff') : user?.role}
             </p>
           </div>
           <button
@@ -30,7 +32,7 @@ export default function Header() {
             className="flex items-center gap-2 bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 transition-colors"
           >
             <LogOut size={16} />
-            התנתק
+            {t('header.logout')}
           </button>
         </div>
       </div>

--- a/src/components/MainApp.tsx
+++ b/src/components/MainApp.tsx
@@ -4,7 +4,9 @@ import Header from './Header';
 import CaseForm from './CaseForm';
 import CasesList from './CasesList';
 import AdminPanel from './AdminPanel';
+import ProfileSettings from './ProfileSettings';
 import { Case, caseService } from '../services/caseService';
+import { useLanguage } from '../contexts/LanguageContext';
 
 export default function MainApp() {
   const { user } = useAuth();
@@ -12,6 +14,7 @@ export default function MainApp() {
   const [searchTerm, setSearchTerm] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [activeTab, setActiveTab] = useState('cases');
+  const { t } = useLanguage();
 
   useEffect(() => {
     loadCases();
@@ -28,7 +31,7 @@ export default function MainApp() {
   };
 
   const handleClearAll = async () => {
-    if (confirm('האם למחוק את כל הדיונים לצמיתות?')) {
+    if (confirm(t('main.confirmClear'))) {
       await caseService.clearAllCases();
       setCases([]);
     }
@@ -46,26 +49,26 @@ export default function MainApp() {
       <div className={`${isLoading ? 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50' : 'hidden'}`}>
         <div className="bg-white rounded-lg p-6 text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <div className="text-xl">מעבד...</div>
+          <div className="text-xl">{t('main.processing')}</div>
         </div>
       </div>
 
       <Header />
-      
+
       <main className="flex-1 p-6 max-w-6xl mx-auto w-full">
-        {user?.role === 'admin' && (
-          <div className="mb-6 border-b border-gray-200">
-            <nav className="flex space-x-8">
-              <button
-                onClick={() => setActiveTab('cases')}
-                className={`py-2 px-1 border-b-2 font-medium text-sm ${
-                  activeTab === 'cases'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                דיונים משפטיים
-              </button>
+        <div className="mb-6 border-b border-gray-200">
+          <nav className="flex space-x-8">
+            <button
+              onClick={() => setActiveTab('cases')}
+              className={`py-2 px-1 border-b-2 font-medium text-sm ${
+                activeTab === 'cases'
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {t('main.tab.cases')}
+            </button>
+            {user?.role === 'admin' && (
               <button
                 onClick={() => setActiveTab('admin')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
@@ -74,11 +77,21 @@ export default function MainApp() {
                     : 'border-transparent text-gray-500 hover:text-gray-700'
                 }`}
               >
-                ניהול מערכת
+                {t('main.tab.admin')}
               </button>
-            </nav>
-          </div>
-        )}
+            )}
+            <button
+              onClick={() => setActiveTab('profile')}
+              className={`py-2 px-1 border-b-2 font-medium text-sm ${
+                activeTab === 'profile'
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {t('main.tab.profile')}
+            </button>
+          </nav>
+        </div>
 
         {activeTab === 'cases' && (
           <>
@@ -91,7 +104,7 @@ export default function MainApp() {
             <div className="mt-6 flex gap-4 items-center">
               <input
                 type="text"
-                placeholder="חיפוש בדיונים..."
+                placeholder={t('main.search.placeholder')}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -100,7 +113,7 @@ export default function MainApp() {
                 onClick={handleClearAll}
                 className="bg-red-600 text-white px-6 py-2 rounded-md hover:bg-red-700 transition-colors"
               >
-                נקה הכל
+                {t('main.clearAll')}
               </button>
             </div>
 
@@ -110,6 +123,10 @@ export default function MainApp() {
 
         {activeTab === 'admin' && user?.role === 'admin' && (
           <AdminPanel />
+        )}
+
+        {activeTab === 'profile' && (
+          <ProfileSettings />
         )}
       </main>
     </div>

--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useLanguage, Language } from '../contexts/LanguageContext';
+import { legalFormTemplates } from '../templates/legalForms';
+
+export default function ProfileSettings() {
+  const { language, setLanguage, t } = useLanguage();
+  const [selectedForm, setSelectedForm] = useState<'powerOfAttorney' | 'complaint'>('powerOfAttorney');
+  const template = legalFormTemplates[language][selectedForm];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block mb-2">{t('profile.language')}</label>
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value as Language)}
+          className="border rounded p-2"
+        >
+          <option value="en">English</option>
+          <option value="he">עברית</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block mb-2">{t('profile.templates')}</label>
+        <select
+          value={selectedForm}
+          onChange={(e) => setSelectedForm(e.target.value as 'powerOfAttorney' | 'complaint')}
+          className="border rounded p-2 mb-2"
+        >
+          <option value="powerOfAttorney">{t('profile.templates.powerOfAttorney')}</option>
+          <option value="complaint">{t('profile.templates.complaint')}</option>
+        </select>
+        <textarea
+          className="w-full h-40 border rounded p-2"
+          value={template}
+          readOnly
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import en from '../i18n/en.json';
+import he from '../i18n/he.json';
+
+type Language = 'en' | 'he';
+
+type Translations = typeof en;
+
+const dictionaries: Record<Language, Translations> = { en, he };
+
+interface LanguageContextValue {
+  language: Language;
+  t: (key: keyof Translations, vars?: Record<string, string>) => string;
+  setLanguage: (lang: Language) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => (localStorage.getItem('lang') as Language) || 'en');
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang);
+    localStorage.setItem('lang', lang);
+  };
+
+  const t = (key: keyof Translations, vars: Record<string, string> = {}) => {
+    let text = dictionaries[language][key] || key;
+    Object.entries(vars).forEach(([k, v]) => {
+      text = text.replace(`{{${k}}}`, v);
+    });
+    return text;
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider');
+  return ctx;
+}
+
+export type { Language };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,23 @@
+{
+  "app.loading": "Loading...",
+  "header.title": "HyperCourt",
+  "header.subtitle": "Smart legal system",
+  "header.welcome": "Welcome, {{email}}",
+  "header.roles.admin": "Administrator",
+  "header.roles.lawyer": "Lawyer",
+  "header.roles.judge": "Judge",
+  "header.roles.plaintiff": "Plaintiff",
+  "header.logout": "Logout",
+  "header.profile": "Profile",
+  "main.processing": "Processing...",
+  "main.tab.cases": "Legal Cases",
+  "main.tab.admin": "System Management",
+  "main.tab.profile": "Profile Settings",
+  "main.search.placeholder": "Search cases...",
+  "main.clearAll": "Clear All",
+  "main.confirmClear": "Delete all cases permanently?",
+  "profile.language": "Language Preference",
+  "profile.templates": "Legal Form Templates",
+  "profile.templates.powerOfAttorney": "Power of Attorney",
+  "profile.templates.complaint": "Complaint"
+}

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -1,0 +1,23 @@
+{
+  "app.loading": "טוען...",
+  "header.title": "HyperCourt",
+  "header.subtitle": "מערכת משפטית חכמה",
+  "header.welcome": "ברוך הבא, {{email}}",
+  "header.roles.admin": "מנהל מערכת",
+  "header.roles.lawyer": "עורך/ת דין",
+  "header.roles.judge": "שופט/ת",
+  "header.roles.plaintiff": "תובע/ת",
+  "header.logout": "התנתק",
+  "header.profile": "פרופיל",
+  "main.processing": "מעבד...",
+  "main.tab.cases": "דיונים משפטיים",
+  "main.tab.admin": "ניהול מערכת",
+  "main.tab.profile": "הגדרות פרופיל",
+  "main.search.placeholder": "חיפוש בדיונים...",
+  "main.clearAll": "נקה הכל",
+  "main.confirmClear": "האם למחוק את כל הדיונים לצמיתות?",
+  "profile.language": "בחירת שפה",
+  "profile.templates": "תבניות טפסים משפטיים",
+  "profile.templates.powerOfAttorney": "ייפוי כוח",
+  "profile.templates.complaint": "כתב תביעה"
+}

--- a/src/templates/legalForms.ts
+++ b/src/templates/legalForms.ts
@@ -1,0 +1,12 @@
+import { Language } from '../contexts/LanguageContext';
+
+export const legalFormTemplates: Record<Language, { powerOfAttorney: string; complaint: string }> = {
+  en: {
+    powerOfAttorney: `POWER OF ATTORNEY\n\nI, [Client Name], hereby appoint [Attorney Name] as my lawful representative in all matters concerning [Case Details].`,
+    complaint: `COMPLAINT\n\nPlaintiff: [Name]\nDefendant: [Name]\nFacts: [Details]\nRelief Sought: [Relief]`
+  },
+  he: {
+    powerOfAttorney: `ייפוי כוח\n\nאני, [שם הלקוח], ממנה בזאת את [שם עורך הדין] כנציגי החוקי בכל הנוגע ל[פרטי המקרה].`,
+    complaint: `כתב תביעה\n\nתובע: [שם]\nנתבע: [שם]\nעובדות: [פרטים]\nסעד מבוקש: [סעד]`
+  }
+};


### PR DESCRIPTION
## Summary
- introduce language context and translation files
- allow users to change interface language in profile settings
- include translated legal form templates

## Testing
- `npm test` *(fails: EJSONPARSE Invalid package.json)*
- `npm run lint` *(fails: EJSONPARSE Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689610212c8c8323a1b58ff2ef01ec52