### PR TITLE
Add community forum screen and API

### DIFF
--- a/backend/models/CommunityThread.js
+++ b/backend/models/CommunityThread.js
@@ -1,0 +1,13 @@
+class CommunityThread {
+  constructor({ id, caseId, title, comments = [] }) {
+    this.id = id;
+    this.caseId = caseId;
+    this.title = title;
+    this.comments = comments;
+    this.createdAt = new Date().toISOString();
+  }
+}
+
+const threads = [];
+
+module.exports = { CommunityThread, threads };

--- a/backend/routes/community.js
+++ b/backend/routes/community.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/auth');
+const { CommunityThread, threads } = require('../models/CommunityThread');
+
+const router = express.Router();
+
+// Get all threads
+router.get('/threads', (req, res) => {
+  res.json(threads);
+});
+
+// Create a new thread linked to a case
+router.post('/threads', authMiddleware, (req, res) => {
+  const { caseId, title } = req.body;
+  if (!caseId || !title) {
+    return res.status(400).json({ error: 'caseId and title are required' });
+  }
+  const thread = new CommunityThread({
+    id: Date.now().toString(),
+    caseId,
+    title,
+  });
+  threads.push(thread);
+  res.status(201).json(thread);
+});
+
+// Add a comment to a thread
+router.post('/threads/:id/comments', authMiddleware, (req, res) => {
+  const thread = threads.find(t => t.id === req.params.id);
+  if (!thread) {
+    return res.status(404).json({ error: 'Thread not found' });
+  }
+  const { content } = req.body;
+  if (!content) {
+    return res.status(400).json({ error: 'content is required' });
+  }
+  const comment = {
+    id: Date.now().toString(),
+    author: req.user ? req.user.email : 'anonymous',
+    content,
+    createdAt: new Date().toISOString(),
+  };
+  thread.comments.push(comment);
+  res.status(201).json(comment);
+});
+
+module.exports = router;

--- a/src/components/community/Forum.tsx
+++ b/src/components/community/Forum.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+interface Comment {
+  id: string;
+  author: string;
+  content: string;
+  createdAt: string;
+}
+
+interface Thread {
+  id: string;
+  caseId: string;
+  title: string;
+  comments: Comment[];
+}
+
+export default function Forum() {
+  const [threads, setThreads] = useState<Thread[]>([]);
+
+  useEffect(() => {
+    fetch('/api/community/threads')
+      .then(res => res.json())
+      .then(data => setThreads(data))
+      .catch(err => console.error('Failed to load threads', err));
+  }, []);
+
+  if (threads.length === 0) {
+    return <div className="p-4 text-center text-gray-500">אין דיונים זמינים.</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {threads.map(thread => (
+        <div key={thread.id} className="p-4 bg-white rounded shadow">
+          <h2 className="text-lg font-semibold">
+            {thread.title}{' '}
+            <a
+              href={`/cases/${thread.caseId}`}
+              className="text-blue-600 hover:underline"
+            >
+              תיק {thread.caseId}
+            </a>
+          </h2>
+          <ul className="mt-2 space-y-2">
+            {thread.comments.map(comment => (
+              <li key={comment.id} className="border-t pt-2">
+                <p className="text-sm text-gray-700">{comment.content}</p>
+                <p className="text-xs text-gray-400">{comment.author}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory CommunityThread model for storing forum discussions
- create community routes to handle threads and comments tied to case IDs
- introduce React Forum component to display threads with links to case files

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689623814d248323a09a3cdd290a3251