### PR TITLE
feat: add live chat with content filtering

### DIFF
--- a/backend/services/socket.js
+++ b/backend/services/socket.js
@@ -1,0 +1,48 @@
+const { Server } = require('socket.io');
+
+const bannedUsers = new Set();
+const bannedWords = ['badword1', 'badword2'];
+
+function isClean(message) {
+  const regex = new RegExp(bannedWords.join('|'), 'i');
+  return !regex.test(message);
+}
+
+function initSocket(httpServer) {
+  const io = new Server(httpServer, {
+    cors: { origin: '*' },
+  });
+
+  io.use((socket, next) => {
+    const userId = socket.handshake.auth?.userId;
+    if (userId && bannedUsers.has(userId)) {
+      return next(new Error('blocked'));
+    }
+    socket.userId = userId || socket.id;
+    next();
+  });
+
+  io.on('connection', (socket) => {
+    socket.on('chat-message', (msg) => {
+      if (!isClean(msg)) {
+        socket.emit('chat-error', 'Message contains prohibited content');
+        return;
+      }
+      io.emit('chat-message', { userId: socket.userId, message: msg });
+    });
+
+    socket.on('block-user', (id) => {
+      if (!id) return;
+      bannedUsers.add(id);
+      for (const [sid, s] of io.sockets.sockets) {
+        if (s.userId === id) {
+          s.disconnect(true);
+        }
+      }
+    });
+  });
+
+  return io;
+}
+
+module.exports = { initSocket, bannedUsers };

--- a/src/components/viewer/LiveChat.tsx
+++ b/src/components/viewer/LiveChat.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+interface ChatMessage {
+  userId: string;
+  message: string;
+}
+
+let socket: Socket | null = null;
+
+const LiveChat = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    socket = io('/', {
+      auth: { userId: localStorage.getItem('userId') || '' },
+    });
+
+    socket.on('chat-message', (msg: ChatMessage) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+
+    socket.on('chat-error', (err: string) => {
+      setError(err);
+    });
+
+    socket.on('connect_error', (err) => {
+      setError(err.message);
+    });
+
+    return () => {
+      socket?.disconnect();
+    };
+  }, []);
+
+  const sendMessage = () => {
+    if (input.trim()) {
+      socket?.emit('chat-message', input.trim());
+      setInput('');
+    }
+  };
+
+  const blockUser = (userId: string) => {
+    socket?.emit('block-user', userId);
+  };
+
+  return (
+    <div>
+      {error && <div className="text-red-500">{error}</div>}
+      <div className="h-64 overflow-y-auto border p-2 mb-2">
+        {messages.map((m, idx) => (
+          <div key={idx}>
+            <span className="font-bold mr-1">{m.userId}:</span>
+            <span>{m.message}</span>
+            <button
+              className="ml-2 text-xs text-red-500"
+              onClick={() => blockUser(m.userId)}
+            >
+              Block
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border p-1"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+        />
+        <button className="px-2 bg-blue-500 text-white" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LiveChat;


### PR DESCRIPTION
## Summary
- add viewer LiveChat component powered by Socket.IO
- create backend socket service with message filtering and user blocking

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896237936808323a16a7bf4f90905da