### PR TITLE
Add invitation link endpoint and viewer invite button

### DIFF
--- a/backend/routes/invites.js
+++ b/backend/routes/invites.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const crypto = require('crypto');
+const { authMiddleware, users } = require('../middleware/auth');
+
+const router = express.Router();
+
+// In-memory storage for invites
+const invites = [];
+
+// Create a unique invitation link
+router.post('/create', authMiddleware, (req, res) => {
+  const code = crypto.randomBytes(8).toString('hex');
+  const invite = { code, inviterId: req.user.userId, used: false };
+  invites.push(invite);
+  const link = `${req.protocol}://${req.get('host')}/signup?invite=${code}`;
+  res.json({ link });
+});
+
+// Redeem an invitation link and credit referral points
+router.post('/use/:code', (req, res) => {
+  const { code } = req.params;
+  const { userId } = req.body;
+  const invite = invites.find(i => i.code === code);
+  if (!invite) {
+    return res.status(404).json({ error: 'Invalid invite code' });
+  }
+  if (invite.used) {
+    return res.status(400).json({ error: 'Invite already used' });
+  }
+  invite.used = true;
+  invite.usedBy = userId;
+  const inviter = users.find(u => u.id === invite.inviterId);
+  if (inviter) {
+    inviter.referralPoints = (inviter.referralPoints || 0) + 1;
+  }
+  res.json({ message: 'Invite accepted' });
+});
+
+module.exports = router;

--- a/src/components/viewer/ViewerDashboard.tsx
+++ b/src/components/viewer/ViewerDashboard.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+export default function ViewerDashboard() {
+  const [inviteLink, setInviteLink] = useState('');
+
+  const handleInvite = async () => {
+    try {
+      const res = await fetch('/api/invites/create', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`
+        }
+      });
+      const data = await res.json();
+      setInviteLink(data.link);
+    } catch (err) {
+      console.error('Failed to create invite', err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <button
+        onClick={handleInvite}
+        className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
+      >
+        Invite
+      </button>
+      {inviteLink && (
+        <p className="mt-4 break-all">{inviteLink}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add invites route to generate and redeem unique invite links with referral point tracking
- show Invite button on viewer dashboard to request a link from backend

## Testing
- `npm test` *(fails: Invalid package.json due to merge conflict markers)*

------
https://chatgpt.com/codex/tasks/task_e_68962376fe508323960c51192603d045