### PR TITLE
Add poll feature for viewer and organizer

### DIFF
--- a/backend/routes/polls.js
+++ b/backend/routes/polls.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const { authMiddleware, requireRole } = require('../middleware/auth');
+
+class Poll {
+  constructor(question, options, createdBy) {
+    this.id = Date.now().toString();
+    this.question = question;
+    this.options = options.map((text, idx) => ({ id: idx.toString(), text, votes: 0 }));
+    this.createdBy = createdBy;
+    this.createdAt = new Date().toISOString();
+  }
+}
+
+const polls = [];
+
+const router = express.Router();
+
+router.post('/', authMiddleware, requireRole(['admin', 'judge']), (req, res) => {
+  const { question, options } = req.body;
+  if (!question || !Array.isArray(options) || options.length < 2) {
+    return res.status(400).json({ error: 'invalid poll data' });
+  }
+  const poll = new Poll(question, options, req.user.email);
+  polls.push(poll);
+  res.status(201).json(poll);
+});
+
+router.get('/:id', authMiddleware, (req, res) => {
+  const poll = polls.find(p => p.id === req.params.id);
+  if (!poll) {
+    return res.status(404).json({ error: 'poll not found' });
+  }
+  res.json(poll);
+});
+
+router.post('/:id/vote', authMiddleware, (req, res) => {
+  const poll = polls.find(p => p.id === req.params.id);
+  if (!poll) {
+    return res.status(404).json({ error: 'poll not found' });
+  }
+  const { optionId } = req.body;
+  const option = poll.options.find(o => o.id === optionId);
+  if (!option) {
+    return res.status(400).json({ error: 'invalid option' });
+  }
+  option.votes += 1;
+  res.json(poll);
+});
+
+router.get('/:id/results', authMiddleware, requireRole(['admin', 'judge']), (req, res) => {
+  const poll = polls.find(p => p.id === req.params.id);
+  if (!poll) {
+    return res.status(404).json({ error: 'poll not found' });
+  }
+  res.json(poll);
+});
+
+module.exports = router;

--- a/src/components/viewer/PollWidget.tsx
+++ b/src/components/viewer/PollWidget.tsx
@@ -1,0 +1,94 @@
+import { useAuth } from '../../contexts/AuthContext';
+import { useEffect, useState } from 'react';
+
+interface PollOption { id: string; text: string; votes: number; }
+interface Poll { id: string; question: string; options: PollOption[]; }
+
+export function PollWidget({ pollId }: { pollId: string }) {
+  const { user } = useAuth();
+  const [poll, setPoll] = useState<Poll | null>(null);
+  const [selected, setSelected] = useState('');
+  const [results, setResults] = useState<PollOption[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/polls/${pollId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setPoll(data);
+        setResults(data.options);
+      }
+    }
+    load();
+  }, [pollId]);
+
+  useEffect(() => {
+    if (user && (user.role === 'admin' || user.role === 'judge')) {
+      const timer = setInterval(async () => {
+        const res = await fetch(`/polls/${pollId}/results`);
+        if (res.ok) {
+          const data = await res.json();
+          setResults(data.options);
+        }
+      }, 2000);
+      return () => clearInterval(timer);
+    }
+  }, [user, pollId]);
+
+  const vote = async () => {
+    if (!selected) return;
+    const res = await fetch(`/polls/${pollId}/vote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ optionId: selected })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setResults(data.options);
+    }
+  };
+
+  if (!poll) return <div>Loading...</div>;
+
+  const total = results.reduce((sum, o) => sum + o.votes, 0);
+  const showResults = user && (user.role === 'admin' || user.role === 'judge');
+
+  return (
+    <div>
+      <h3>{poll.question}</h3>
+      {poll.options.map(o => (
+        <div key={o.id}>
+          <label>
+            <input
+              type="radio"
+              value={o.id}
+              checked={selected === o.id}
+              onChange={e => setSelected(e.target.value)}
+              disabled={showResults}
+            />
+            {o.text}
+          </label>
+          {showResults && (
+            <div style={{ background: '#eee', height: '8px', width: '100%' }}>
+              <div
+                style={{
+                  background: '#3b82f6',
+                  height: '8px',
+                  width: total ? `${(results.find(r => r.id === o.id)?.votes || 0) / total * 100}%` : '0%'
+                }}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+      {!showResults && <button onClick={vote} disabled={!selected}>Vote</button>}
+      {!showResults && total > 0 && (
+        <div>
+          {results.map(o => (
+            <div key={o.id}>{o.text} - {o.votes}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory poll model with CRUD and vote routes
- create PollWidget component for voting and live results

## Testing
- `npm test` *(fails: JSON.parse Invalid package.json)*
- `npm run lint` *(fails: JSON.parse Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962372cc588323aac9a96ed3b80cb7