### PR TITLE
feat: add viewer profile center

### DIFF
--- a/src/components/viewer/ProfileCenter.tsx
+++ b/src/components/viewer/ProfileCenter.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { viewerProfileService, ViewerProfile } from '../../services/viewerProfileService';
+import { useAuth } from '../../contexts/AuthContext';
+
+export default function ProfileCenter() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<ViewerProfile>({
+    id: user?.email || 'guest',
+    watchHistory: [],
+    notificationPreferences: { email: true, sms: false },
+    avatarImage: ''
+  });
+
+  useEffect(() => {
+    if (!user) return;
+    viewerProfileService.getProfile(user.email).then(saved => {
+      if (saved) setProfile(saved);
+    });
+  }, [user]);
+
+  const handlePrefChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    setProfile(prev => ({
+      ...prev,
+      notificationPreferences: {
+        ...prev.notificationPreferences,
+        [name]: checked
+      }
+    }));
+  };
+
+  const handleSave = async () => {
+    await viewerProfileService.saveProfile(profile);
+    viewerProfileService.tailorContent(profile);
+    alert('Profile saved');
+  };
+
+  if (!user) {
+    return <div>אנא התחבר כדי לערוך פרופיל</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h2 className="text-xl font-bold mb-4">פרופיל צופה</h2>
+
+      <div className="mb-4">
+        <label className="block mb-1 font-medium">תמונת אוואטר (URL)</label>
+        <input
+          className="w-full border p-2"
+          value={profile.avatarImage}
+          onChange={e => setProfile({ ...profile, avatarImage: e.target.value })}
+        />
+      </div>
+
+      <div className="mb-4">
+        <h3 className="font-medium mb-1">העדפות התראות</h3>
+        <label className="block">
+          <input
+            type="checkbox"
+            name="email"
+            checked={profile.notificationPreferences.email}
+            onChange={handlePrefChange}
+            className="mr-2"
+          />
+          מייל
+        </label>
+        <label className="block">
+          <input
+            type="checkbox"
+            name="sms"
+            checked={profile.notificationPreferences.sms}
+            onChange={handlePrefChange}
+            className="mr-2"
+          />
+          SMS
+        </label>
+      </div>
+
+      <div className="mb-4">
+        <h3 className="font-medium mb-1">היסטוריית צפייה</h3>
+        {profile.watchHistory.length === 0 ? (
+          <p>אין היסטוריה</p>
+        ) : (
+          <ul className="list-disc pl-5">
+            {profile.watchHistory.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        onClick={handleSave}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        שמור
+      </button>
+    </div>
+  );
+}

--- a/src/services/viewerProfileService.ts
+++ b/src/services/viewerProfileService.ts
@@ -1,0 +1,67 @@
+const DB_NAME = 'courtDBv6';
+const STORE_NAME = 'viewer_profile';
+
+export interface ViewerProfile {
+  id: string;
+  watchHistory: string[];
+  notificationPreferences: {
+    email: boolean;
+    sms: boolean;
+  };
+  avatarImage: string;
+}
+
+class ViewerProfileService {
+  private async openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, 1);
+      request.onupgradeneeded = event => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async getProfile(id: string): Promise<ViewerProfile | null> {
+    try {
+      const db = await this.openDB();
+      return new Promise(resolve => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.get(id);
+        request.onsuccess = () => resolve(request.result || null);
+      });
+    } catch (error) {
+      console.warn('Could not read viewer profile from IndexedDB', error);
+      return null;
+    }
+  }
+
+  async saveProfile(profile: ViewerProfile): Promise<void> {
+    try {
+      const db = await this.openDB();
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put(profile);
+    } catch (error) {
+      console.warn('Could not save viewer profile to IndexedDB', error);
+    }
+  }
+
+  tailorContent(profile: ViewerProfile): string[] {
+    const types: string[] = [];
+    if (profile.notificationPreferences.email) {
+      types.push('legal-news');
+    }
+    if (profile.notificationPreferences.sms) {
+      types.push('case-updates');
+    }
+    return types;
+  }
+}
+
+export const viewerProfileService = new ViewerProfileService();


### PR DESCRIPTION
## Summary
- add IndexedDB-backed viewer profile service
- create profile center component for editing viewer preferences

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find module 'react')*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896236a06788323a41892054489375e