### PR TITLE
Add challenge model, service, and list UI

### DIFF
--- a/backend/models/challenge.js
+++ b/backend/models/challenge.js
@@ -1,0 +1,16 @@
+class Challenge {
+  constructor(type, date, completionCondition) {
+    this.type = type;
+    this.date = date;
+    this.completionCondition = completionCondition;
+    this.progress = 0;
+    this.completed = false;
+  }
+
+  updateProgress(value) {
+    this.progress = value;
+    this.completed = this.completionCondition(value);
+  }
+}
+
+module.exports = Challenge;

--- a/backend/services/challengeService.js
+++ b/backend/services/challengeService.js
@@ -1,0 +1,27 @@
+const Challenge = require('../models/challenge');
+
+const challenges = [];
+
+function addChallenge(type, date, completionCondition) {
+  const challenge = new Challenge(type, date, completionCondition);
+  challenges.push(challenge);
+  return challenge;
+}
+
+function trackProgress(type, value) {
+  const challenge = challenges.find(c => c.type === type);
+  if (challenge) {
+    challenge.updateProgress(value);
+  }
+  return challenge;
+}
+
+function listChallenges() {
+  return challenges;
+}
+
+module.exports = {
+  addChallenge,
+  trackProgress,
+  listChallenges
+};

--- a/src/components/gamification/ChallengeList.tsx
+++ b/src/components/gamification/ChallengeList.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+
+interface Challenge {
+  type: string;
+  date: string;
+  completed: boolean;
+}
+
+export default function ChallengeList() {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+
+  useEffect(() => {
+    async function loadChallenges() {
+      try {
+        const res = await fetch('/api/challenges');
+        if (!res.ok) {
+          throw new Error('Failed to fetch challenges');
+        }
+        const data = await res.json();
+        setChallenges(data);
+      } catch (err) {
+        console.error('Error loading challenges', err);
+      }
+    }
+
+    loadChallenges();
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Challenges</h2>
+      <ul className="space-y-2">
+        {challenges.map(challenge => (
+          <li key={challenge.type} className="flex justify-between p-2 border rounded">
+            <span>{challenge.type}</span>
+            <span>{new Date(challenge.date).toLocaleDateString()}</span>
+            <span>{challenge.completed ? 'Completed' : 'In Progress'}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Challenge model with progress tracking
- implement challenge service for creating and updating challenges
- render challenge list UI with status display

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689611aef41c8323b27bcd87025ee7bb