### PR TITLE
Add pro bono tracking and leaderboard UI

### DIFF
--- a/backend/models/proBonoLog.js
+++ b/backend/models/proBonoLog.js
@@ -1,0 +1,38 @@
+const proBonoLogs = [];
+
+function logProBonoHours(userId, hours, details = '') {
+  const parsedHours = Number(hours);
+  if (!userId || Number.isNaN(parsedHours) || parsedHours <= 0) {
+    return;
+  }
+  proBonoLogs.push({
+    userId,
+    hours: parsedHours,
+    details,
+    timestamp: new Date().toISOString()
+  });
+}
+
+function getUserTotalHours(userId) {
+  return proBonoLogs
+    .filter(log => log.userId === userId)
+    .reduce((sum, log) => sum + log.hours, 0);
+}
+
+function getLeaderboard(limit = 10) {
+  const totals = {};
+  for (const log of proBonoLogs) {
+    totals[log.userId] = (totals[log.userId] || 0) + log.hours;
+  }
+  return Object.entries(totals)
+    .map(([userId, hours]) => ({ userId, hours }))
+    .sort((a, b) => b.hours - a.hours)
+    .slice(0, limit);
+}
+
+module.exports = {
+  proBonoLogs,
+  logProBonoHours,
+  getUserTotalHours,
+  getLeaderboard
+};

--- a/backend/routes/leaderboard.js
+++ b/backend/routes/leaderboard.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const { authMiddleware, users } = require('../middleware/auth');
+const { getLeaderboard } = require('../models/proBonoLog');
+
+const router = express.Router();
+
+router.get('/pro-bono', authMiddleware, (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const leaderboard = getLeaderboard(limit).map(entry => {
+    const user = users.find(u => u.id === entry.userId);
+    return {
+      userId: entry.userId,
+      name: user ? user.name : 'Unknown',
+      hours: entry.hours
+    };
+  });
+  res.json(leaderboard);
+});
+
+module.exports = router;

--- a/src/components/gamification/Leaderboard.tsx
+++ b/src/components/gamification/Leaderboard.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+
+interface LeaderboardEntry {
+  userId: string;
+  name: string;
+  hours: number;
+}
+
+export default function Leaderboard() {
+  const [data, setData] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const token = localStorage.getItem('hypercourt_token');
+        const response = await fetch('http://localhost:5001/api/leaderboard/pro-bono', {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined
+        });
+        if (!response.ok) {
+          throw new Error('Failed to load');
+        }
+        const json = await response.json();
+        setData(json);
+      } catch (err) {
+        setError('שגיאה בטעינת לוח ההובלה');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <div>טוען...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="mb-4 text-xl font-bold">לוח פרו בונו</h2>
+      <ol className="space-y-2">
+        {data.map((entry, index) => (
+          <li
+            key={entry.userId}
+            className="flex justify-between rounded bg-white p-2 shadow"
+          >
+            <span>{index + 1}. {entry.name}</span>
+            <span>{entry.hours} שעות</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- track pro bono hours in a shared log
- expose /pro-bono leaderboard endpoint
- show leaderboard in new React component

## Testing
- `npm test` (fails: Invalid package.json: JSONParseError)
- `npm run lint` (fails: Invalid package.json: JSONParseError)


------
https://chatgpt.com/codex/tasks/task_e_689611aab8a48323abb29d0f963c0137