### PR TITLE
Add achievement system and attorney profile tags

### DIFF
--- a/backend/services/achievementService.js
+++ b/backend/services/achievementService.js
@@ -1,0 +1,25 @@
+const ACHIEVEMENTS = [
+  { id: 'rookie', name: 'Rookie Attorney', minCases: 5, minSuccessRate: 0.5 },
+  { id: 'seasoned', name: 'Seasoned Counsel', minCases: 20, minSuccessRate: 0.7 },
+  { id: 'veteran', name: 'Veteran Litigator', minCases: 50, minSuccessRate: 0.85 }
+];
+
+function calculateAchievements(caseCount, successRate) {
+  return ACHIEVEMENTS.filter(
+    a => caseCount >= a.minCases && successRate >= a.minSuccessRate
+  );
+}
+
+function assignAchievements(attorney) {
+  const achievements = calculateAchievements(
+    attorney.caseCount,
+    attorney.successRate
+  );
+  return { ...attorney, achievements };
+}
+
+module.exports = {
+  ACHIEVEMENTS,
+  calculateAchievements,
+  assignAchievements
+};

--- a/src/components/profile/AttorneyProfile.tsx
+++ b/src/components/profile/AttorneyProfile.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export interface Achievement {
+  id: string;
+  name: string;
+}
+
+export interface Attorney {
+  name: string;
+  achievements: Achievement[];
+}
+
+export const AttorneyProfile: React.FC<{ attorney: Attorney }> = ({ attorney }) => {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold">{attorney.name}</h2>
+      <div className="flex flex-wrap gap-2 mt-2">
+        {attorney.achievements.map((ach) => (
+          <span
+            key={ach.id}
+            className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm"
+          >
+            {ach.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AttorneyProfile;


### PR DESCRIPTION
## Summary
- add achievement calculation service on backend
- show attorney achievements in profile component

## Testing
- `npm test` *(fails: Invalid package.json JSON.parse)*

------
https://chatgpt.com/codex/tasks/task_e_689611a78d588323aed564f85c797a87