### PR TITLE
Add quote management form and backend API

### DIFF
--- a/backend/models/quote.js
+++ b/backend/models/quote.js
@@ -1,0 +1,37 @@
+const quotes = [];
+const clients = [];
+
+function createQuote({ client, details, amount, status = 'draft' }) {
+  const quote = {
+    id: Date.now().toString(),
+    client,
+    details,
+    amount,
+    status
+  };
+  quotes.push(quote);
+  return quote;
+}
+
+function setStatus(id, status) {
+  const quote = quotes.find(q => q.id === id);
+  if (!quote) return null;
+  quote.status = status;
+  return quote;
+}
+
+function activateQuote(id) {
+  const quote = setStatus(id, 'accepted');
+  if (!quote) return null;
+  const client = {
+    id: quote.id,
+    name: quote.client,
+    details: quote.details,
+    amount: quote.amount
+  };
+  clients.push(client);
+  return client;
+}
+
+module.exports = { quotes, clients, createQuote, setStatus, activateQuote };
+

--- a/backend/routes/quotes.js
+++ b/backend/routes/quotes.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const { createQuote, setStatus, activateQuote } = require('../models/quote');
+
+const router = express.Router();
+
+router.post('/', (req, res) => {
+  const { client, details, amount, status } = req.body;
+  const quote = createQuote({ client, details, amount, status });
+  res.status(201).json(quote);
+});
+
+router.post('/:id/send', (req, res) => {
+  const quote = setStatus(req.params.id, 'sent');
+  if (!quote) {
+    return res.status(404).json({ error: 'Quote not found' });
+  }
+  res.json(quote);
+});
+
+router.post('/:id/activate', (req, res) => {
+  const client = activateQuote(req.params.id);
+  if (!client) {
+    return res.status(404).json({ error: 'Quote not found' });
+  }
+  res.json({ message: 'Quote converted to active client', client });
+});
+
+module.exports = router;
+

--- a/src/components/quotes/QuoteForm.tsx
+++ b/src/components/quotes/QuoteForm.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+
+interface QuoteFormProps {
+  onCreated?: (quote: { id: string; client: string; details: string; amount: number; status: string }) => void;
+}
+
+export default function QuoteForm({ onCreated }: QuoteFormProps) {
+  const [client, setClient] = useState('');
+  const [details, setDetails] = useState('');
+  const [amount, setAmount] = useState('');
+  const [status, setStatus] = useState('draft');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!client.trim() || !amount.trim()) {
+      setError('כל השדות נדרשים');
+      return;
+    }
+
+    const quote = { client, details, amount: parseFloat(amount), status };
+
+    try {
+      const response = await fetch('/api/quotes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(quote)
+      });
+      const saved = await response.json();
+      onCreated?.(saved);
+      setClient('');
+      setDetails('');
+      setAmount('');
+      setStatus('draft');
+      setError('');
+    } catch {
+      setError('שמירת הצעת המחיר נכשלה');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">שם לקוח</label>
+        <input
+          value={client}
+          onChange={e => setClient(e.target.value)}
+          className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">תיאור</label>
+        <textarea
+          value={details}
+          onChange={e => setDetails(e.target.value)}
+          className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">סכום</label>
+        <input
+          type="number"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">סטטוס</label>
+        <select
+          value={status}
+          onChange={e => setStatus(e.target.value)}
+          className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="draft">טיוטה</option>
+          <option value="sent">נשלח</option>
+          <option value="accepted">התקבל</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="text-red-600 text-sm">{error}</div>
+      )}
+
+      <button
+        type="submit"
+        className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+      >
+        שמור הצעה
+      </button>
+    </form>
+  );
+}
+
+


### PR DESCRIPTION
## Summary
- add QuoteForm component for creating quotes
- store quotes with status and client activation model
- expose routes to send and activate quotes

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896119f18f0832383d5b191054412cc