### PR TITLE
Add client model, CRUD routes, and list component

### DIFF
--- a/backend/models/client.js
+++ b/backend/models/client.js
@@ -1,0 +1,14 @@
+class Client {
+  constructor({ id, name, email, phone, history = [] }) {
+    this.id = id || Date.now().toString();
+    this.name = name;
+    this.email = email;
+    this.phone = phone;
+    this.history = history;
+    this.createdAt = new Date().toISOString();
+  }
+}
+
+const clients = [];
+
+module.exports = { Client, clients };

--- a/backend/routes/clients.js
+++ b/backend/routes/clients.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/auth');
+const { Client, clients } = require('../models/client');
+
+const router = express.Router();
+
+router.get('/', authMiddleware, (req, res) => {
+  res.json(clients);
+});
+
+router.get('/:id', authMiddleware, (req, res) => {
+  const client = clients.find(c => c.id === req.params.id);
+  if (!client) {
+    return res.status(404).json({ error: 'לקוח לא נמצא' });
+  }
+  res.json(client);
+});
+
+router.post('/', authMiddleware, (req, res) => {
+  const { name, email, phone, history = [] } = req.body;
+  if (!name || !email || !phone) {
+    return res.status(400).json({ error: 'חסרים פרטי לקוח' });
+  }
+  const client = new Client({ name, email, phone, history });
+  clients.push(client);
+  res.status(201).json(client);
+});
+
+router.put('/:id', authMiddleware, (req, res) => {
+  const client = clients.find(c => c.id === req.params.id);
+  if (!client) {
+    return res.status(404).json({ error: 'לקוח לא נמצא' });
+  }
+  const { name, email, phone, history } = req.body;
+  if (name !== undefined) client.name = name;
+  if (email !== undefined) client.email = email;
+  if (phone !== undefined) client.phone = phone;
+  if (history !== undefined) client.history = history;
+  res.json(client);
+});
+
+router.delete('/:id', authMiddleware, (req, res) => {
+  const index = clients.findIndex(c => c.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'לקוח לא נמצא' });
+  }
+  const removed = clients.splice(index, 1)[0];
+  res.json(removed);
+});
+
+module.exports = router;

--- a/src/components/clients/ClientList.tsx
+++ b/src/components/clients/ClientList.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+interface Client {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  history: string[];
+}
+
+export default function ClientList() {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('hypercourt_token');
+    fetch('http://localhost:5001/api/clients', {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+      .then(async res => {
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to load clients');
+        }
+        return res.json();
+      })
+      .then(data => setClients(data))
+      .catch(err => setError(err.message));
+  }, []);
+
+  if (error) {
+    return <div className="text-red-600">{error}</div>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {clients.map(client => (
+        <div key={client.id} className="border rounded p-2">
+          <div className="font-semibold">{client.name}</div>
+          <div className="text-sm text-gray-600">{client.email} | {client.phone}</div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory Client model with contact details and history
- provide CRUD API for clients with auth protection
- create React component to fetch and display clients

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896119de05c8323865f3a147771bd98