### PR TITLE
Add subscription management and billing scheduler

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,9 @@
+const subscriptionPackages = [
+  { id: 'basic', name: 'Basic', price: 50, interval: 'month' },
+  { id: 'pro', name: 'Pro', price: 100, interval: 'month' },
+  { id: 'enterprise', name: 'Enterprise', price: 250, interval: 'month' }
+];
+
+const clientSubscriptions = [];
+
+module.exports = { subscriptionPackages, clientSubscriptions };

--- a/backend/routes/subscriptions.js
+++ b/backend/routes/subscriptions.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/auth');
+const { subscriptionPackages, clientSubscriptions } = require('../db');
+
+const router = express.Router();
+
+router.get('/packages', (req, res) => {
+  res.json(subscriptionPackages);
+});
+
+router.post('/subscribe', authMiddleware, (req, res) => {
+  const { packageId } = req.body;
+  const pkg = subscriptionPackages.find(p => p.id === packageId);
+  if (!pkg) {
+    return res.status(404).json({ error: 'חבילה לא נמצאה' });
+  }
+
+  const existing = clientSubscriptions.find(s => s.clientId === req.user.userId);
+  const nextBillingDate = new Date();
+  nextBillingDate.setMonth(nextBillingDate.getMonth() + 1);
+
+  if (existing) {
+    existing.packageId = packageId;
+    existing.nextBillingDate = nextBillingDate.toISOString();
+  } else {
+    clientSubscriptions.push({
+      id: Date.now().toString(),
+      clientId: req.user.userId,
+      packageId,
+      nextBillingDate: nextBillingDate.toISOString()
+    });
+  }
+
+  res.json({ message: 'נרשמת בהצלחה' });
+});
+
+module.exports = router;

--- a/backend/services/billingScheduler.js
+++ b/backend/services/billingScheduler.js
@@ -1,0 +1,23 @@
+const { subscriptionPackages, clientSubscriptions } = require('../db');
+
+function processBilling(subscription) {
+  const pkg = subscriptionPackages.find(p => p.id === subscription.packageId);
+  if (!pkg) return;
+  console.log(`Billing client ${subscription.clientId} for ${pkg.name} - ${pkg.price}`);
+  const next = new Date(subscription.nextBillingDate);
+  next.setMonth(next.getMonth() + 1);
+  subscription.nextBillingDate = next.toISOString();
+}
+
+function startBillingScheduler() {
+  setInterval(() => {
+    const now = new Date();
+    clientSubscriptions.forEach(sub => {
+      if (new Date(sub.nextBillingDate) <= now) {
+        processBilling(sub);
+      }
+    });
+  }, 24 * 60 * 60 * 1000);
+}
+
+module.exports = { startBillingScheduler };

--- a/src/components/account/Subscriptions.tsx
+++ b/src/components/account/Subscriptions.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+
+interface SubscriptionPackage {
+  id: string;
+  name: string;
+  price: number;
+  interval: string;
+}
+
+export default function Subscriptions() {
+  const [packages, setPackages] = useState<SubscriptionPackage[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('/api/subscriptions/packages')
+      .then(res => res.json())
+      .then(data => setPackages(data))
+      .catch(() => setPackages([]));
+  }, []);
+
+  const choosePackage = async (packageId: string) => {
+    try {
+      const res = await fetch('/api/subscriptions/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ packageId })
+      });
+      if (res.ok) {
+        setSelected(packageId);
+        setMessage('נרשמת בהצלחה');
+      } else {
+        setMessage('שגיאה בהרשמה');
+      }
+    } catch {
+      setMessage('שגיאה בחיבור');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-gray-800">בחר חבילת מנוי</h2>
+      {packages.map(pkg => (
+        <div
+          key={pkg.id}
+          className={`border p-4 rounded flex items-center justify-between ${selected === pkg.id ? 'border-blue-500' : 'border-gray-200'}`}
+        >
+          <div>
+            <p className="font-semibold">{pkg.name}</p>
+            <p className="text-sm text-gray-600">{pkg.price}₪ / {pkg.interval}</p>
+          </div>
+          <button
+            onClick={() => choosePackage(pkg.id)}
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            בחר
+          </button>
+        </div>
+      ))}
+      {message && <p className="text-green-600">{message}</p>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- define in-memory tables for subscription packages and client subscriptions
- expose subscription APIs and billing scheduler
- add client UI for selecting subscription packages

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689611a1f70483239534664904fe5fa5