### PR TITLE
Add audit logging middleware and admin log viewer

### DIFF
--- a/backend/middleware/auditLogger.js
+++ b/backend/middleware/auditLogger.js
@@ -1,0 +1,23 @@
+const auditLogs = [];
+
+function createAuditLogger(action) {
+  return (req, res, next) => {
+    const user = req.user ? req.user.email || req.user.id : 'anonymous';
+    auditLogs.push({
+      user,
+      action,
+      timestamp: new Date().toISOString()
+    });
+    next();
+  };
+}
+
+function queryLogs(filters = {}) {
+  return auditLogs.filter(log => {
+    if (filters.user && log.user !== filters.user) return false;
+    if (filters.action && log.action !== filters.action) return false;
+    return true;
+  });
+}
+
+module.exports = { createAuditLogger, queryLogs, auditLogs };

--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const { authMiddleware } = require('../middleware/auth');
+const { createAuditLogger } = require('../middleware/auditLogger');
+
+const router = express.Router();
+
+let cases = [];
+
+// Create case
+router.post('/', authMiddleware, createAuditLogger('create_case'), (req, res) => {
+  const caseData = { id: Date.now().toString(), ...req.body };
+  cases.push(caseData);
+  res.status(201).json(caseData);
+});
+
+// Edit case
+router.put('/:id', authMiddleware, createAuditLogger('edit_case'), (req, res) => {
+  const index = cases.findIndex(c => c.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Case not found' });
+  }
+  cases[index] = { ...cases[index], ...req.body };
+  res.json(cases[index]);
+});
+
+// Delete case
+router.delete('/:id', authMiddleware, createAuditLogger('delete_case'), (req, res) => {
+  const index = cases.findIndex(c => c.id === req.params.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Case not found' });
+  }
+  const removed = cases.splice(index, 1)[0];
+  res.json(removed);
+});
+
+module.exports = router;

--- a/backend/routes/logs.js
+++ b/backend/routes/logs.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { authMiddleware, requireRole } = require('../middleware/auth');
+const { queryLogs } = require('../middleware/auditLogger');
+
+const router = express.Router();
+
+router.get('/', authMiddleware, requireRole(['admin']), (req, res) => {
+  const { user, action } = req.query;
+  const logs = queryLogs({ user, action });
+  res.json(logs);
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const cors = require('cors');
+const authRoutes = require('./routes/auth');
+const aiRoutes = require('./routes/ai');
+const caseRoutes = require('./routes/cases');
+const logRoutes = require('./routes/logs');
+const { users } = require('./middleware/auth');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/ai', aiRoutes);
+app.use('/api/cases', caseRoutes);
+app.use('/api/logs', logRoutes);
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok', users: users.length });
+});
+
+const PORT = process.env.PORT || 5001;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,6 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { Users, Database, Settings, Activity, Shield, AlertTriangle } from 'lucide-react';
 
+interface LogFilters {
+  user: string;
+  action: string;
+}
+
+interface AuditLog {
+  user: string;
+  action: string;
+  timestamp: string;
+}
+
 export default function AdminPanel() {
   const [stats, setStats] = useState({
     totalUsers: 0,
@@ -8,11 +19,18 @@ export default function AdminPanel() {
     systemHealth: 'תקין',
     lastBackup: 'לא זמין'
   });
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [logFilters, setLogFilters] = useState<LogFilters>({ user: '', action: '' });
 
   useEffect(() => {
     // Load admin statistics
     loadStats();
+    loadLogs();
   }, []);
+
+  useEffect(() => {
+    loadLogs();
+  }, [logFilters]);
 
   const loadStats = async () => {
     try {
@@ -88,6 +106,27 @@ export default function AdminPanel() {
       };
     } catch (error) {
       alert('שגיאה ביצירת גיבוי: ' + error);
+    }
+  };
+
+  const loadLogs = async () => {
+    try {
+      const params = new URLSearchParams();
+      if (logFilters.user) params.append('user', logFilters.user);
+      if (logFilters.action) params.append('action', logFilters.action);
+      const token = localStorage.getItem('hypercourt_token');
+      const response = await fetch(`http://localhost:5001/api/logs?${params.toString()}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {}
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setLogs(data);
+      } else {
+        setLogs([]);
+      }
+    } catch (error) {
+      console.warn('Could not load audit logs:', error);
+      setLogs([]);
     }
   };
 
@@ -222,6 +261,47 @@ export default function AdminPanel() {
             <p>• סביבת הפעלה: {import.meta.env.PROD ? 'Production' : 'Development'}</p>
             <p>• בסיס נתונים: IndexedDB (מקומי)</p>
             <p>• שרת אימות: Node.js + Express</p>
+          </div>
+        </div>
+
+        {/* Audit Logs */}
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold text-gray-800 mb-4">יומן פעולות</h3>
+          <div className="flex gap-2 mb-4">
+            <input
+              type="text"
+              placeholder="משתמש"
+              className="border rounded p-2 flex-1"
+              value={logFilters.user}
+              onChange={e => setLogFilters(prev => ({ ...prev, user: e.target.value }))}
+            />
+            <input
+              type="text"
+              placeholder="פעולה"
+              className="border rounded p-2 flex-1"
+              value={logFilters.action}
+              onChange={e => setLogFilters(prev => ({ ...prev, action: e.target.value }))}
+            />
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">משתמש</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">פעולה</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">זמן</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {logs.map((log, index) => (
+                  <tr key={index}>
+                    <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{log.user}</td>
+                    <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{log.action}</td>
+                    <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{new Date(log.timestamp).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- track user actions in new audit log middleware
- log case create/edit/delete events
- provide admin UI to filter and view audit logs

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896101e8a4c8323bf54ba689a2ea88e