### PR TITLE
feat: add db utils and toast notifications

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ToastProvider } from './src/components/Toast';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>
 );

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Users, Database, Settings, Activity, Shield, AlertTriangle } from 'lucide-react';
+import { getAllCases, getCaseCount, clearCases } from '../utils/db';
+import { useToast } from './Toast';
 
 interface LogFilters {
   user: string;
@@ -21,9 +23,9 @@ export default function AdminPanel() {
   });
   const [logs, setLogs] = useState<AuditLog[]>([]);
   const [logFilters, setLogFilters] = useState<LogFilters>({ user: '', action: '' });
+  const toast = useToast();
 
   useEffect(() => {
-    // Load admin statistics
     loadStats();
     loadLogs();
   }, []);
@@ -44,31 +46,16 @@ export default function AdminPanel() {
           systemHealth: 'תקין'
         }));
       }
-    } catch (error) {
+    } catch {
       setStats(prev => ({
         ...prev,
         systemHealth: 'שגיאה בחיבור'
       }));
     }
 
-    // Get cases count from IndexedDB
     try {
-      const db = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('courtDBv6', 1);
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-      });
-
-      const transaction = db.transaction('cases', 'readonly');
-      const store = transaction.objectStore('cases');
-      const countRequest = store.count();
-      
-      countRequest.onsuccess = () => {
-        setStats(prev => ({
-          ...prev,
-          totalCases: countRequest.result
-        }));
-      };
+      const totalCases = await getCaseCount();
+      setStats(prev => ({ ...prev, totalCases }));
     } catch (error) {
       console.warn('Could not get cases count:', error);
     }
@@ -76,36 +63,23 @@ export default function AdminPanel() {
 
   const exportData = async () => {
     try {
-      const db = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('courtDBv6', 1);
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-      });
-
-      const transaction = db.transaction('cases', 'readonly');
-      const store = transaction.objectStore('cases');
-      const request = store.getAll();
-      
-      request.onsuccess = () => {
-        const data = {
-          exportDate: new Date().toISOString(),
-          cases: request.result,
-          totalCases: request.result.length
-        };
-        
-        const blob = new Blob([JSON.stringify(data, null, 2)], { 
-          type: 'application/json' 
-        });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = `hypercourt_backup_${new Date().toISOString().split('T')[0]}.json`;
-        link.click();
-        URL.revokeObjectURL(link.href);
-        
-        alert('גיבוי הנתונים הושלם בהצלחה!');
+      const cases = await getAllCases();
+      const data = {
+        exportDate: new Date().toISOString(),
+        cases,
+        totalCases: cases.length
       };
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json'
+      });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `hypercourt_backup_${new Date().toISOString().split('T')[0]}.json`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+      toast('גיבוי הנתונים הושלם בהצלחה!');
     } catch (error) {
-      alert('שגיאה ביצירת גיבוי: ' + error);
+      toast('שגיאה ביצירת גיבוי: ' + error);
     }
   };
 
@@ -133,20 +107,11 @@ export default function AdminPanel() {
   const clearSystemData = async () => {
     if (confirm('האם אתה בטוח שברצונך למחוק את כל נתוני המערכת? פעולה זו בלתי הפיכה!')) {
       try {
-        const db = await new Promise<IDBDatabase>((resolve, reject) => {
-          const request = indexedDB.open('courtDBv6', 1);
-          request.onsuccess = () => resolve(request.result);
-          request.onerror = () => reject(request.error);
-        });
-
-        const transaction = db.transaction('cases', 'readwrite');
-        const store = transaction.objectStore('cases');
-        store.clear();
-        
-        alert('כל נתוני המערכת נמחקו בהצלחה!');
+        await clearCases();
+        toast('כל נתוני המערכת נמחקו בהצלחה!');
         loadStats();
       } catch (error) {
-        alert('שגיאה במחיקת נתונים: ' + error);
+        toast('שגיאה במחיקת נתונים: ' + error);
       }
     }
   };

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+type ToastContextType = (message: string) => void
+
+const ToastContext = createContext<ToastContextType>(() => {})
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<string | null>(null)
+
+  const show = (msg: string) => {
+    setMessage(msg)
+    setTimeout(() => setMessage(null), 3000)
+  }
+
+  return (
+    <ToastContext.Provider value={show}>
+      {children}
+      {message && (
+        <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
+          {message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  )
+}
+
+export const useToast = () => useContext(ToastContext)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { ToastProvider } from './components/Toast';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>
 );

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,37 @@
+import type { Case } from '../services/caseService'
+
+const DB_NAME = 'courtDBv6'
+const STORE_NAME = 'cases'
+
+export const openDB = async (): Promise<IDBDatabase> => new Promise((resolve, reject) => {
+  const request = indexedDB.open(DB_NAME, 1)
+  request.onsuccess = () => resolve(request.result)
+  request.onerror = () => reject(request.error)
+})
+
+export const getAllCases = async (): Promise<Case[]> => {
+  const db = await openDB()
+  return new Promise<Case[]>((resolve, reject) => {
+    const request = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).getAll()
+    request.onsuccess = () => resolve(request.result as Case[])
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export const getCaseCount = async (): Promise<number> => {
+  const db = await openDB()
+  return new Promise<number>((resolve, reject) => {
+    const request = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).count()
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export const clearCases = async (): Promise<void> => {
+  const db = await openDB()
+  return new Promise<void>((resolve, reject) => {
+    const request = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).clear()
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error)
+  })
+}


### PR DESCRIPTION
## Summary
- add IndexedDB helper with open, count, fetch, and clear functions
- replace AdminPanel alerts and DB calls with helpers and toast notifications
- wrap app with ToastProvider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: see errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc15e7688323b7156a679cde1adb