### PR TITLE
feat: implement secure token handling

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -6,6 +6,22 @@ const { body, validationResult } = require('express-validator');
 const { users } = require('../middleware/auth');
 
 const router = express.Router();
+const refreshTokens = [];
+
+function generateTokens(user) {
+  const accessToken = jwt.sign(
+    { userId: user.id, email: user.email, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: '15m' }
+  );
+  const refreshToken = jwt.sign(
+    { userId: user.id },
+    process.env.JWT_SECRET,
+    { expiresIn: '7d' }
+  );
+  refreshTokens.push({ token: refreshToken, userId: user.id });
+  return { accessToken, refreshToken };
+}
 
 // Rate limiting for auth endpoints
 const authLimiter = rateLimit({
@@ -68,18 +84,20 @@ router.post('/register',
 
       users.push(user);
 
-      // Generate JWT
-      const token = jwt.sign(
-        { userId: user.id, email: user.email, role: user.role },
-        process.env.JWT_SECRET,
-        { expiresIn: '24h' }
-      );
+      const { accessToken, refreshToken } = generateTokens(user);
+
+      res.cookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        maxAge: 604800000
+      });
 
       console.log(`New user registered: ${email} (${role})`);
 
       res.status(201).json({
         message: 'משתמש נוצר בהצלחה',
-        token,
+        token: accessToken,
         user: {
           id: user.id,
           email: user.email,
@@ -129,18 +147,20 @@ router.post('/login',
         return res.status(401).json({ error: 'אימייל או סיסמה שגויים' });
       }
 
-      // Generate JWT
-      const token = jwt.sign(
-        { userId: user.id, email: user.email, role: user.role },
-        process.env.JWT_SECRET,
-        { expiresIn: '24h' }
-      );
+      const { accessToken, refreshToken } = generateTokens(user);
+
+      res.cookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        maxAge: 604800000
+      });
 
       console.log(`User logged in: ${email} (${user.role})`);
 
       res.json({
         message: 'התחברת בהצלחה',
-        token,
+        token: accessToken,
         user: {
           id: user.id,
           email: user.email,
@@ -158,5 +178,58 @@ router.post('/login',
     }
   }
 );
+
+router.post('/refresh', async (req, res) => {
+  const token = req.cookies?.refreshToken;
+  if (!token) {
+    return res.status(401).json({ error: 'Missing refresh token' });
+  }
+
+  const stored = refreshTokens.find(t => t.token === token);
+  if (!stored) {
+    return res.status(401).json({ error: 'Invalid refresh token' });
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const user = users.find(u => u.id === payload.userId);
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
+
+    const { accessToken, refreshToken } = generateTokens(user);
+    refreshTokens.splice(refreshTokens.indexOf(stored), 1);
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      maxAge: 604800000
+    });
+
+    res.json({ token: accessToken, user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      points: user.points,
+      referralCode: user.referralCode,
+      referrerId: user.referrerId
+    }});
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid refresh token' });
+  }
+});
+
+router.post('/logout', (req, res) => {
+  const token = req.cookies?.refreshToken;
+  if (token) {
+    const index = refreshTokens.findIndex(t => t.token === token);
+    if (index !== -1) {
+      refreshTokens.splice(index, 1);
+    }
+  }
+  res.clearCookie('refreshToken', { httpOnly: true, secure: true, sameSite: 'strict' });
+  res.json({ message: 'התנתקת בהצלחה' });
+});
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 const authRoutes = require('./routes/auth');
 const aiRoutes = require('./routes/ai');
 const caseRoutes = require('./routes/cases');
@@ -7,8 +8,9 @@ const logRoutes = require('./routes/logs');
 const { users } = require('./middleware/auth');
 
 const app = express();
-app.use(cors());
+app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
 app.use(express.json());
+app.use(cookieParser());
 
 app.use('/api/auth', authRoutes);
 app.use('/api/ai', aiRoutes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "chart.js": "^4.4.0",
+        "cookie-parser": "^1.4.6",
         "dompurify": "^3.2.6",
         "jspdf": "^2.5.1",
         "lucide-react": "^0.344.0",
@@ -2122,6 +2123,34 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.4.0",
+    "cookie-parser": "^1.4.6",
     "dompurify": "^3.2.6",
+    "jspdf": "^2.5.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1",
-    "chart.js": "^4.4.0",
-    "react-chartjs-2": "^5.2.0",
-    "jspdf": "^2.5.1"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- add HTTP-only cookie refresh tokens and in-memory access tokens
- introduce refresh token endpoint and logout handling
- update AuthContext and authService for secure token flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, merge conflict marker)*

------
https://chatgpt.com/codex/tasks/task_e_6896fbef04388323a45bf11b12db4a57