### PR TITLE
feat: add user model and database auth

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+async function connectDB() {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/court';
+  mongoose.set('strictQuery', true);
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
+
+module.exports = { connectDB };

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,16 +1,13 @@
 const jwt = require('jsonwebtoken');
 
-// In-memory user storage (replace with database in production)
-const users = [];
-
 function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  
+
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'לא מחובר - נדרש טוקן אימות' });
   }
 
-  const token = authHeader.substring(7); // Remove 'Bearer ' prefix
+  const token = authHeader.substring(7);
 
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
@@ -37,4 +34,4 @@ function requireRole(roles) {
   };
 }
 
-module.exports = { authMiddleware, requireRole, users };
+module.exports = { authMiddleware, requireRole };

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  name: { type: String, required: true },
+  role: { type: String, enum: ['admin', 'lawyer', 'plaintiff', 'judge'], required: true },
+  createdAt: { type: Date, default: Date.now },
+  points: { type: Number, default: 0 },
+  referralCode: { type: String, unique: true },
+  referrerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null }
+});
+
+// Remove sensitive fields when converting to JSON
+userSchema.set('toJSON', {
+  transform: function (doc, ret) {
+    ret.id = ret._id;
+    delete ret._id;
+    delete ret.__v;
+    delete ret.password;
+    return ret;
+  }
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -3,21 +3,22 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const rateLimit = require('express-rate-limit');
 const { body, validationResult } = require('express-validator');
-const { users } = require('../middleware/auth');
+const User = require('../models/User');
 
 const router = express.Router();
 
 // Rate limiting for auth endpoints
 const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 5, // limit each IP to 5 requests per windowMs
+  windowMs: 15 * 60 * 1000,
+  max: 5,
   message: 'יותר מדי ניסיונות התחברות, נסה שוב בעוד 15 דקות',
   standardHeaders: true,
   legacyHeaders: false,
 });
 
 // Registration endpoint
-router.post('/register', 
+router.post(
+  '/register',
   authLimiter,
   [
     body('email').isEmail().withMessage('כתובת אימייל לא תקינה'),
@@ -29,16 +30,16 @@ router.post('/register',
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
-        return res.status(400).json({ 
-          error: 'נתונים לא תקינים', 
-          details: errors.array() 
+        return res.status(400).json({
+          error: 'נתונים לא תקינים',
+          details: errors.array()
         });
       }
 
       const { email, password, name, role } = req.body;
 
       // Check if user already exists
-      const existingUser = users.find(u => u.email === email);
+      const existingUser = await User.findOne({ email });
       if (existingUser) {
         return res.status(400).json({ error: 'משתמש עם אימייל זה כבר קיים' });
       }
@@ -51,22 +52,17 @@ router.post('/register',
       let referralCode;
       do {
         referralCode = Math.random().toString(36).substring(2, 8);
-      } while (users.find(u => u.referralCode === referralCode));
+      } while (await User.findOne({ referralCode }));
 
-      // Create user with referral fields
-      const user = {
-        id: Date.now().toString(),
+      // Create user
+      const user = new User({
         email,
         password: hashedPassword,
         name,
         role,
-        createdAt: new Date().toISOString(),
-        points: 0,
-        referralCode,
-        referrerId: null
-      };
-
-      users.push(user);
+        referralCode
+      });
+      await user.save();
 
       // Generate JWT
       const token = jwt.sign(
@@ -80,17 +76,8 @@ router.post('/register',
       res.status(201).json({
         message: 'משתמש נוצר בהצלחה',
         token,
-        user: {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          role: user.role,
-          points: user.points,
-          referralCode: user.referralCode,
-          referrerId: user.referrerId
-        }
+        user: user.toJSON()
       });
-
     } catch (error) {
       console.error('Registration error:', error);
       res.status(500).json({ error: 'שגיאה ביצירת משתמש' });
@@ -99,7 +86,8 @@ router.post('/register',
 );
 
 // Login endpoint
-router.post('/login',
+router.post(
+  '/login',
   authLimiter,
   [
     body('email').isEmail().withMessage('כתובת אימייל לא תקינה'),
@@ -109,16 +97,16 @@ router.post('/login',
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
-        return res.status(400).json({ 
-          error: 'נתונים לא תקינים', 
-          details: errors.array() 
+        return res.status(400).json({
+          error: 'נתונים לא תקינים',
+          details: errors.array()
         });
       }
 
       const { email, password } = req.body;
 
       // Find user
-      const user = users.find(u => u.email === email);
+      const user = await User.findOne({ email });
       if (!user) {
         return res.status(401).json({ error: 'אימייל או סיסמה שגויים' });
       }
@@ -141,17 +129,8 @@ router.post('/login',
       res.json({
         message: 'התחברת בהצלחה',
         token,
-        user: {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          role: user.role,
-          points: user.points,
-          referralCode: user.referralCode,
-          referrerId: user.referrerId
-        }
+        user: user.toJSON()
       });
-
     } catch (error) {
       console.error('Login error:', error);
       res.status(500).json({ error: 'שגיאה בהתחברות' });

--- a/backend/routes/referrals.js
+++ b/backend/routes/referrals.js
@@ -1,30 +1,38 @@
 const express = require('express');
-const { users } = require('../middleware/auth');
+const User = require('../models/User');
 
 const router = express.Router();
 
 // Assign points to referrer when a client joins with a referral code
-router.post('/join', (req, res) => {
+router.post('/join', async (req, res) => {
   const { clientId, referralCode } = req.body;
 
-  const client = users.find(u => u.id === clientId);
-  if (!client) {
-    return res.status(404).json({ error: 'לקוח לא נמצא' });
+  try {
+    const client = await User.findById(clientId);
+    if (!client) {
+      return res.status(404).json({ error: 'לקוח לא נמצא' });
+    }
+
+    if (client.referrerId) {
+      return res.status(400).json({ error: 'הלקוח כבר שויך למפנה' });
+    }
+
+    const referrer = await User.findOne({ referralCode });
+    if (!referrer) {
+      return res.status(404).json({ error: 'קוד הפניה לא תקין' });
+    }
+
+    client.referrerId = referrer._id;
+    await client.save();
+
+    referrer.points = (referrer.points || 0) + 1;
+    await referrer.save();
+
+    res.json({ message: 'הנקודות הוקצו', referrerPoints: referrer.points });
+  } catch (err) {
+    console.error('Referral error:', err);
+    res.status(500).json({ error: 'שגיאה בעיבוד הפניה' });
   }
-
-  if (client.referrerId) {
-    return res.status(400).json({ error: 'הלקוח כבר שויך למפנה' });
-  }
-
-  const referrer = users.find(u => u.referralCode === referralCode);
-  if (!referrer) {
-    return res.status(404).json({ error: 'קוד הפניה לא תקין' });
-  }
-
-  client.referrerId = referrer.id;
-  referrer.points = (referrer.points || 0) + 1;
-
-  res.json({ message: 'הנקודות הוקצו', referrerPoints: referrer.points });
 });
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,22 +1,30 @@
 const express = require('express');
 const cors = require('cors');
+const { connectDB } = require('./config/db');
 const authRoutes = require('./routes/auth');
 const aiRoutes = require('./routes/ai');
 const caseRoutes = require('./routes/cases');
 const logRoutes = require('./routes/logs');
-const { users } = require('./middleware/auth');
+const User = require('./models/User');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+connectDB().catch(err => console.error('DB connection error:', err));
 
 app.use('/api/auth', authRoutes);
 app.use('/api/ai', aiRoutes);
 app.use('/api/cases', caseRoutes);
 app.use('/api/logs', logRoutes);
 
-app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', users: users.length });
+app.get('/api/health', async (req, res) => {
+  try {
+    const count = await User.countDocuments();
+    res.json({ status: 'ok', users: count });
+  } catch (err) {
+    res.json({ status: 'ok', users: 0 });
+  }
 });
 
 const PORT = process.env.PORT || 5001;


### PR DESCRIPTION
## Summary
- add MongoDB connection helper and User model
- implement auth and referral routes using database-backed users with hashed passwords
- connect server to database and expose user count in health endpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68963227d3e88323b13e15dffab7bfca