### PR TITLE
Use configurable API URL

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,5 @@
+# Gemini API key
 GEMINI_API_KEY=PLACEHOLDER_API_KEY
+
+# URL of the backend API
+VITE_API_URL=http://localhost:5001/api

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,6 +1,6 @@
-const API_BASE_URL = import.meta.env.PROD 
-  ? 'https://api.hypercourt.com' 
-  : 'http://localhost:5001';
+const API_BASE_URL =
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.PROD ? 'https://api.hypercourt.com/api' : 'http://localhost:5001/api');
 
 interface ApiResponse<T = any> {
   data?: T;
@@ -57,7 +57,7 @@ class ApiClient {
     }
 
     try {
-      const response = await fetch(`${this.baseURL}/api/auth/refresh`, {
+        const response = await fetch(`${this.baseURL}/auth/refresh`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -138,7 +138,7 @@ class ApiClient {
     name: string;
     role?: string;
   }): Promise<ApiResponse<TokenResponse>> {
-    const response = await this.makeRequest<TokenResponse>('/api/auth/register', {
+      const response = await this.makeRequest<TokenResponse>('/auth/register', {
       method: 'POST',
       body: JSON.stringify(userData),
     });
@@ -157,7 +157,7 @@ class ApiClient {
     email: string;
     password: string;
   }): Promise<ApiResponse<TokenResponse>> {
-    const response = await this.makeRequest<TokenResponse>('/api/auth/login', {
+      const response = await this.makeRequest<TokenResponse>('/auth/login', {
       method: 'POST',
       body: JSON.stringify(credentials),
     });
@@ -174,7 +174,7 @@ class ApiClient {
 
   async logout(): Promise<void> {
     if (this.refreshToken) {
-      await this.makeRequest('/api/auth/logout', {
+        await this.makeRequest('/auth/logout', {
         method: 'POST',
         body: JSON.stringify({ refreshToken: this.refreshToken }),
       });
@@ -183,7 +183,7 @@ class ApiClient {
   }
 
   async getProfile(): Promise<ApiResponse<{ user: any }>> {
-    return this.makeRequest('/api/auth/profile');
+    return this.makeRequest('/auth/profile');
   }
 
   // Health check

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -12,6 +12,8 @@ interface AuditLog {
   timestamp: string;
 }
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
+
 export default function AdminPanel() {
   const [stats, setStats] = useState({
     totalUsers: 0,
@@ -35,7 +37,7 @@ export default function AdminPanel() {
   const loadStats = async () => {
     try {
       // Check backend health
-      const response = await fetch('http://localhost:5001/api/health');
+      const response = await fetch(`${API_URL}/health`);
       if (response.ok) {
         const data = await response.json();
         setStats(prev => ({
@@ -115,7 +117,7 @@ export default function AdminPanel() {
       if (logFilters.user) params.append('user', logFilters.user);
       if (logFilters.action) params.append('action', logFilters.action);
       const token = localStorage.getItem('hypercourt_token');
-      const response = await fetch(`http://localhost:5001/api/logs?${params.toString()}`, {
+        const response = await fetch(`${API_URL}/logs?${params.toString()}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {}
       });
       if (response.ok) {
@@ -242,7 +244,7 @@ export default function AdminPanel() {
 
             <button
               className="flex items-center gap-3 bg-purple-600 text-white p-4 rounded-lg hover:bg-purple-700 transition-colors"
-              onClick={() => window.open('http://localhost:5001/api/health', '_blank')}
+              onClick={() => window.open(`${API_URL}/health`, '_blank')}
             >
               <Settings size={20} />
               <div className="text-right">

--- a/src/components/clients/ClientList.tsx
+++ b/src/components/clients/ClientList.tsx
@@ -8,13 +8,15 @@ interface Client {
   history: string[];
 }
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
+
 export default function ClientList() {
   const [clients, setClients] = useState<Client[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem('hypercourt_token');
-    fetch('http://localhost:5001/api/clients', {
+    fetch(`${API_URL}/clients`, {
       headers: {
         Authorization: `Bearer ${token}`
       }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,4 +1,4 @@
-const API_URL = 'http://localhost:5001/api';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
 
 export const aiService = {
   async chat(messages: any[], model: string) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,5 @@
-const API_URL = 'http://localhost:5001/api/auth';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
+const AUTH_URL = `${API_URL}/auth`;
 
 // Enhanced request handling with timeout and better error messages
 const fetchWithTimeout = async (url: string, options: RequestInit, timeout = 10000) => {
@@ -49,7 +50,7 @@ const handleApiError = (data: any, response: Response) => {
 export const authService = {
   async login(email: string, password: string) {
     try {
-      const response = await fetchWithTimeout(`${API_URL}/login`, {
+      const response = await fetchWithTimeout(`${AUTH_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
@@ -68,7 +69,7 @@ export const authService = {
 
   async register(email: string, password: string, role: string, name: string) {
     try {
-      const response = await fetchWithTimeout(`${API_URL}/register`, {
+      const response = await fetchWithTimeout(`${AUTH_URL}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password, role, name })
@@ -88,7 +89,7 @@ export const authService = {
   async getProfile() {
     try {
       const token = localStorage.getItem('hypercourt_token');
-      const response = await fetchWithTimeout(`${API_URL.replace('/auth', '')}/profile`, {
+        const response = await fetchWithTimeout(`${API_URL}/profile`, {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- load API base URL from `VITE_API_URL` env variable
- document default API URL in `.env.local`
- use configured URL across services and components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected lexical declaration in case block, Unexpected any, Parsing error: Merge conflict marker encountered)*

------
https://chatgpt.com/codex/tasks/task_e_6896322cdf4083238d824929e346b289