### PR TITLE
Centralize logo component and update header usage

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { LogOut } from 'lucide-react';
+import Logo from './Logo';
 
 export default function Header() {
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-blue-800">HyperCourt</h1>
-          <p className="text-sm text-gray-600">מערכת משפטית חכמה</p>
-        </div>
-        
+        <Logo />
+
         <div className="flex items-center gap-4">
           <div className="text-right">
             <p className="text-sm font-medium text-gray-900">

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <h1 className="text-2xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 font-serif tracking-tight">
+      jus-tice courts
+    </h1>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { LogOut } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
+import Logo from './Logo';
 
 export default function Header() {
   const { user, logout } = useAuth();
@@ -10,10 +11,7 @@ export default function Header() {
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-blue-800">{t('header.title')}</h1>
-          <p className="text-sm text-gray-600">{t('header.subtitle')}</p>
-        </div>
+        <Logo />
         
         <div className="flex items-center gap-4">
           <div className="text-right">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <h1 className="text-2xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 font-serif tracking-tight">
+      jus-tice courts
+    </h1>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Logo component in `frontend/src/components`
- replace hardcoded frontend header title with `<Logo />`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b604052c8323a6cc6976c2c80bac