### PR TITLE
Centralize logo component and update header usage

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { LogOut } from 'lucide-react';
+import Logo from './Logo';
 
 export default function Header() {
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-blue-800">HyperCourt</h1>
-          <p className="text-sm text-gray-600">מערכת משפטית חכמה</p>
-        </div>
-        
+        <Logo />
+
         <div className="flex items-center gap-4">
           <div className="text-right">
             <p className="text-sm font-medium text-gray-900">

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <h1 className="text-2xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 font-serif tracking-tight">
+      jus-tice courts
+    </h1>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "vite-react-typescript-starter",
   "name": "virtual-court",
   "private": true,
   "version": "0.0.0",
@@ -12,26 +11,19 @@
     "test": "node --test backend/__tests__/scheduleService.test.js"
   },
   "dependencies": {
-    "chart.js": "^4.4.0",
-    "cookie-parser": "^1.4.6",
+    "@google/genai": "^1.12.0",
     "@supabase/supabase-js": "^2.54.0",
     "chart.js": "^4.4.0",
-    "@google/genai": "^1.12.0",
+    "cookie-parser": "^1.4.6",
     "dompurify": "^3.2.6",
+    "handlebars": "^4.7.8",
     "jspdf": "^2.5.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
-    "swagger-ui-express": "^5.0.1",
-    "handlebars": "^4.7.8",
-    "chart.js": "^4.4.0",
-    "react-chartjs-2": "^5.2.0",
-    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -46,9 +38,6 @@
     "globals": "^15.9.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "~5.8.2",
-    "typescript-eslint": "^8.3.0",
-    "vite": "^6.2.0"
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { LogOut } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
+import Logo from './Logo';
 
 export default function Header() {
   const { user, logout } = useAuth();
@@ -10,10 +11,7 @@ export default function Header() {
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-blue-800">{t('header.title')}</h1>
-          <p className="text-sm text-gray-600">{t('header.subtitle')}</p>
-        </div>
+        <Logo />
         
         <div className="flex items-center gap-4">
           <div className="text-right">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <h1 className="text-2xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 font-serif tracking-tight">
+      jus-tice courts
+    </h1>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Logo component in `frontend/src/components`
- replace hardcoded frontend header title with `<Logo />`
- clean up `package.json` to remove duplicate entries and consolidate dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b604052c8323a6cc6976c2c80bac